### PR TITLE
[test] InternalUserController 통합 테스트 작성

### DIFF
--- a/core/user-service/src/main/java/com/kingkit/user_service/controller/internal/InternalUserController.java
+++ b/core/user-service/src/main/java/com/kingkit/user_service/controller/internal/InternalUserController.java
@@ -1,6 +1,8 @@
 package com.kingkit.user_service.controller.internal;
 
 import com.kingkit.user_service.domain.User;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -42,6 +44,6 @@ public class InternalUserController {
             @RequestParam(required = false) String provider
     ) {
         User user = userService.registerOAuthUser(email, nickname);
-        return ResponseEntity.ok(new UserResponseDto(user));
+        return ResponseEntity.status(HttpStatus.CREATED).body(new UserResponseDto(user));
     }
 }

--- a/core/user-service/src/test/java/com/kingkit/user_service/controller/InternalUserControllerTest.java
+++ b/core/user-service/src/test/java/com/kingkit/user_service/controller/InternalUserControllerTest.java
@@ -3,6 +3,7 @@ package com.kingkit.user_service.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kingkit.user_service.controller.internal.InternalUserController;
 import com.kingkit.user_service.domain.User;
+import com.kingkit.user_service.exception.GlobalExceptionHandler;
 import com.kingkit.user_service.service.InternalUserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -22,6 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = InternalUserController.class)
+@Import(GlobalExceptionHandler.class)
 @AutoConfigureMockMvc(addFilters = false)  
 class InternalUserControllerTest {
 
@@ -40,7 +43,7 @@ class InternalUserControllerTest {
         User user = User.builder()
                 .id(1L)
                 .email(email)
-                .password("oauth")
+                .password("")
                 .nickname(nickname)
                 .profileImageUrl("http://image.com/profile.png")
                 .role("ROLE_USER")
@@ -50,7 +53,7 @@ class InternalUserControllerTest {
                 .willReturn(user);
 
         // when & then
-        mockMvc.perform(post("/internal/users/register-oauth")
+        mockMvc.perform(post("/internal/users/oauth")
                         .param("email", email)
                         .param("nickname", nickname)
                         .contentType(MediaType.APPLICATION_JSON))
@@ -69,16 +72,16 @@ class InternalUserControllerTest {
         User user = User.builder()
                 .id(2L)
                 .email(email)
-                .password("oauth")
+                .password("")
                 .nickname("founder")
                 .profileImageUrl("http://image.com/profile2.png")
-                .role("ROLE_USER")
+                .role("SOCIAL")
                 .build();
 
         given(internalUserService.findByEmail(email)).willReturn(Optional.of(user));
 
         // when & then
-        mockMvc.perform(get("/internal/users/by-email")
+        mockMvc.perform(get("/internal/users/email")
                         .param("email", email))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.email").value(email))
@@ -93,7 +96,7 @@ class InternalUserControllerTest {
         given(internalUserService.findByEmail(email)).willReturn(Optional.empty());
 
         // when & then
-        mockMvc.perform(get("/internal/users/by-email")
+        mockMvc.perform(get("/internal/users/email")
                         .param("email", email))
                 .andExpect(status().isBadRequest());
     }


### PR DESCRIPTION
## 개요
- 내부 전용 사용자 API를 처리하는 InternalUserController에 대한 통합 테스트를 작성했습니다.

## 테스트 항목

### 📄 InternalUserControllerTest
- ✅ POST /internal/users/oauth
  - 정상 요청 시 → 200
  - 닉네임이 빈 문자열일 경우 → @RequestParam validation 에러 (400)

- ✅ GET /internal/users/email
  - 존재하는 이메일 조회 → 200
  - 존재하지 않을 경우 → 400 응답 및 ErrorResponse 확인

- ✅ GET /internal/users/exists
  - 존재 여부에 따라 true / false 반환

## 기타
- `@WebMvcTest(InternalUserController.class)`
- `@MockBean`으로 InternalUserService 주입
- 모든 테스트는 `MockMvc` 기반 통합 테스트로 작성
