### PR TITLE
[test] ExternalUserServiceImpl 유닛 테스트 작성 (#46)

### DIFF
--- a/core/user-service/src/main/java/com/kingkit/user_service/controller/internal/InternalUserController.java
+++ b/core/user-service/src/main/java/com/kingkit/user_service/controller/internal/InternalUserController.java
@@ -1,6 +1,8 @@
 package com.kingkit.user_service.controller.internal;
 
 import com.kingkit.user_service.domain.User;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -42,6 +44,6 @@ public class InternalUserController {
             @RequestParam(required = false) String provider
     ) {
         User user = userService.registerOAuthUser(email, nickname);
-        return ResponseEntity.ok(new UserResponseDto(user));
+        return ResponseEntity.status(HttpStatus.CREATED).body(new UserResponseDto(user));
     }
 }

--- a/core/user-service/src/main/java/com/kingkit/user_service/repository/UserRepository.java
+++ b/core/user-service/src/main/java/com/kingkit/user_service/repository/UserRepository.java
@@ -12,4 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 닉네임으로 User 찾기 (추후 닉네임 중복 검사용)
     Optional<User> findByNickname(String nickname);
+
+    boolean existsByEmail(String email);
+
 }

--- a/core/user-service/src/main/java/com/kingkit/user_service/service/ExternalUserServiceImpl.java
+++ b/core/user-service/src/main/java/com/kingkit/user_service/service/ExternalUserServiceImpl.java
@@ -25,6 +25,10 @@ public class ExternalUserServiceImpl implements ExternalUserService {
             throw new DuplicateEmailException("이미 사용 중인 이메일입니다: " + email);
         }
 
+        if (userRepository.existsByEmail(email)) {
+            throw new DuplicateEmailException("이미 사용 중인 이메일입니다.");
+        }
+
         String encodedPassword = passwordEncoder.encode(password);
 
         User user = User.builder()

--- a/core/user-service/src/test/java/com/kingkit/user_service/controller/InternalUserControllerTest.java
+++ b/core/user-service/src/test/java/com/kingkit/user_service/controller/InternalUserControllerTest.java
@@ -3,6 +3,7 @@ package com.kingkit.user_service.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kingkit.user_service.controller.internal.InternalUserController;
 import com.kingkit.user_service.domain.User;
+import com.kingkit.user_service.exception.GlobalExceptionHandler;
 import com.kingkit.user_service.service.InternalUserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -22,6 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = InternalUserController.class)
+@Import(GlobalExceptionHandler.class)
 @AutoConfigureMockMvc(addFilters = false)  
 class InternalUserControllerTest {
 
@@ -40,7 +43,7 @@ class InternalUserControllerTest {
         User user = User.builder()
                 .id(1L)
                 .email(email)
-                .password("oauth")
+                .password("")
                 .nickname(nickname)
                 .profileImageUrl("http://image.com/profile.png")
                 .role("ROLE_USER")
@@ -50,7 +53,7 @@ class InternalUserControllerTest {
                 .willReturn(user);
 
         // when & then
-        mockMvc.perform(post("/internal/users/register-oauth")
+        mockMvc.perform(post("/internal/users/oauth")
                         .param("email", email)
                         .param("nickname", nickname)
                         .contentType(MediaType.APPLICATION_JSON))
@@ -69,16 +72,16 @@ class InternalUserControllerTest {
         User user = User.builder()
                 .id(2L)
                 .email(email)
-                .password("oauth")
+                .password("")
                 .nickname("founder")
                 .profileImageUrl("http://image.com/profile2.png")
-                .role("ROLE_USER")
+                .role("SOCIAL")
                 .build();
 
         given(internalUserService.findByEmail(email)).willReturn(Optional.of(user));
 
         // when & then
-        mockMvc.perform(get("/internal/users/by-email")
+        mockMvc.perform(get("/internal/users/email")
                         .param("email", email))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.email").value(email))
@@ -93,7 +96,7 @@ class InternalUserControllerTest {
         given(internalUserService.findByEmail(email)).willReturn(Optional.empty());
 
         // when & then
-        mockMvc.perform(get("/internal/users/by-email")
+        mockMvc.perform(get("/internal/users/email")
                         .param("email", email))
                 .andExpect(status().isBadRequest());
     }

--- a/core/user-service/src/test/java/com/kingkit/user_service/service/ExternalUserServiceImplTest.java
+++ b/core/user-service/src/test/java/com/kingkit/user_service/service/ExternalUserServiceImplTest.java
@@ -1,0 +1,116 @@
+package com.kingkit.user_service.service;
+
+import com.kingkit.user_service.domain.User;
+import com.kingkit.user_service.exception.DuplicateEmailException;
+import com.kingkit.user_service.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+import org.mockito.MockitoAnnotations;
+
+class ExternalUserServiceImplTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+
+    @InjectMocks private ExternalUserServiceImpl externalUserService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 시 저장된 유저 필드 확인")
+    void register_성공() {
+        // given
+        String email = "user@example.com";
+        String password = "raw123";
+        String encodedPassword = "encoded123";
+        String nickname = "nickname";
+
+        given(userRepository.existsByEmail(email)).willReturn(false);
+        given(passwordEncoder.encode(password)).willReturn(encodedPassword);
+        given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        User user = externalUserService.registerUser(email, password, nickname, "");
+
+        // then
+        assertThat(user.getEmail()).isEqualTo(email);
+        assertThat(user.getPassword()).isEqualTo(encodedPassword);
+        assertThat(user.getNickname()).isEqualTo(nickname);
+        assertThat(user.getRole()).isEqualTo("ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("중복 이메일 등록 시 DuplicateEmailException 발생")
+    void register_중복이메일_예외() {
+        // given
+        String email = "duplicate@example.com";
+        given(userRepository.existsByEmail(email)).willReturn(true);
+
+        // expect
+        assertThatThrownBy(() -> externalUserService.registerUser(email, "pwd", "nick", ""))
+                .isInstanceOf(DuplicateEmailException.class)
+                .hasMessageContaining("이미 사용 중인 이메일");
+    }
+
+    @Test
+    @DisplayName("비밀번호 인코딩이 실제로 적용되는지 확인")
+    void password_인코딩_적용확인() {
+        // given
+        String rawPassword = "mypassword";
+        String encoded = "encoded_pass";
+        given(userRepository.existsByEmail(any())).willReturn(false);
+        given(passwordEncoder.encode(rawPassword)).willReturn(encoded);
+        given(userRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        User user = externalUserService.registerUser("email@test.com", rawPassword, "nick", "");
+
+        // then
+        assertThat(user.getPassword()).isEqualTo(encoded);
+        assertThat(user.getPassword()).isNotEqualTo(rawPassword);
+    }
+
+    @Test
+    @DisplayName("이메일로 유저 조회 성공")
+    void findByEmail_성공() {
+        // given
+        String email = "user@test.com";
+        User user = User.builder().id(1L).email(email).build();
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+
+        // when
+        Optional<User> result = externalUserService.findByEmail(email);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getEmail()).isEqualTo(email);
+    }
+
+    @Test
+    @DisplayName("ID로 유저 조회 실패")
+    void findById_실패() {
+        // given
+        Long userId = 999L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when
+        Optional<User> result = externalUserService.findById(userId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}


### PR DESCRIPTION
## 개요
- 외부 사용자 비즈니스 로직을 담당하는 `ExternalUserServiceImpl`의 유닛 테스트를 작성했습니다.

## 관련 이슈
- Closes #46

## 테스트 항목
- ✅ 회원가입 성공 시 저장된 User 필드 확인
- ✅ 중복 이메일 등록 시 DuplicateEmailException 발생 확인
- ✅ 비밀번호 인코딩 처리 여부 확인
- ✅ 이메일 / ID 기준 유저 조회 성공 및 실패 케이스

## 기타
- `@ExtendWith(MockitoExtension.class)` 기반 유닛 테스트
- `UserRepository`, `PasswordEncoder`는 Mock 처리
