### PR TITLE
[chore] GitHub Actions 기반 CI 파이프라인 설정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+# ───────────────────────── 트리거 ─────────────────────────
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ "**" ]
+
+# ───────────────────────── Job 정의 ──────────────────────
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    # JDK 17(= 프로젝트 기본), 필요 시 매트릭스 확장 가능
+    strategy:
+      matrix:
+        java: [ 17 ]
+
+    steps:
+      # 1) 코드 가져오기
+      - name: Check out sources
+        uses: actions/checkout@v4
+
+      # 2) JDK 설정 + 캐시
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: gradle            # → ~/.gradle 캐싱
+
+      # 3) Gradle Wrapper 권한 부여
+      - name: Grant execute permission for Gradle wrapper
+        run: chmod +x gradlew
+
+      # 4) 빌드 & 테스트
+      - name: Build with Gradle
+        run: ./gradlew clean build --no-daemon
+
+      # 5) (선택) 테스트 리포트 아카이빙 - 실패 원인 확인용
+      - name: Upload Test Reports
+        if: failure()              # 빌드 실패시에만
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            **/build/reports/tests/test
+            **/build/reports/spotbugs
+          retention-days: 7


### PR DESCRIPTION
## 개요
- 모든 PR 및 main / develop 브랜치 푸시 시 자동으로 빌드/테스트가 실행되는 GitHub Actions 기반 CI 파이프라인을 설정했습니다.

## 위치
- `.github/workflows/ci.yml`

## 주요 설정

| 항목 | 설명 |
|------|------|
| 트리거 | main, develop 브랜치 push, 모든 PR 대상 |
| JDK | Temurin 기반 JDK 17 |
| 캐시 | Gradle 캐시 자동 적용 |
| 빌드 명령어 | `./gradlew clean build --no-daemon` |
| 테스트 리포트 업로드 | 빌드 실패 시 HTML 리포트 아카이빙 (`build/reports/tests/test/index.html`) |

## 기대 효과
- 테스트 실패나 컴파일 에러를 PR 작성 시점에 즉시 확인 가능
- 향후 배포 파이프라인(CD)과도 자연스럽게 연계 가능
- 팀 내 코드 신뢰도 및 협업 품질 향상
