### PR TITLE
[feat] Terraform: EC2용 SSM Role 모듈화 및 적용

### DIFF
--- a/infra/terraform/data.tf
+++ b/infra/terraform/data.tf
@@ -1,0 +1,26 @@
+# ✅ Amazon Linux 2023 AMI (ARM64)
+data "aws_ami" "amazon_linux_2023_arm64" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023*-arm64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# ✅ 기본 서브넷 (서울 리전 AZ-a)
+data "aws_subnet" "default" {
+  default_for_az    = true
+  availability_zone = "ap-northeast-2a"
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -2,6 +2,16 @@ provider "aws" {
   region = var.region
 }
 
+module "ec2_sg" {
+  source              = "./modules/security_group"
+  name                = "ec2-sg"
+  description         = "Allow SSH access"
+  ingress_from_port   = 22
+  ingress_to_port     = 22
+  ingress_protocol    = "tcp"
+  ingress_cidr_blocks = ["0.0.0.0/0"]
+}
+
 module "rds_sg" {
   source              = "./modules/security_group"
   name                = "rds-security-group"
@@ -13,10 +23,25 @@ module "rds_sg" {
 }
 
 module "auth_db" {
-  source                 = "./modules/rds"
-  identifier             = "auth-db"
-  db_name                = var.db_name
-  db_username            = var.db_username
-  db_password            = var.db_password
-  security_group_id      = module.rds_sg.security_group_id
+  source            = "./modules/rds"
+  identifier        = "auth-db"
+  db_name           = var.db_name
+  db_username       = var.db_username
+  db_password       = var.db_password
+  security_group_id = module.rds_sg.security_group_id
+}
+
+module "ssm_role" {
+  source = "./modules/iam"
+  name   = "ec2-ssm-role"
+}
+
+module "ec2" {
+  source                = "./modules/ec2"
+  name                  = "dev-ec2"
+  instance_type         = "t4g.nano"
+  ami_id                = data.aws_ami.amazon_linux_2023_arm64.id
+  subnet_id             = data.aws_subnet.default.id
+  security_group_id     = module.ec2_sg.security_group_id
+  iam_instance_profile  = module.ssm_role.instance_profile_name  # ✅ 연결
 }

--- a/infra/terraform/modules/ec2/main.tf
+++ b/infra/terraform/modules/ec2/main.tf
@@ -1,0 +1,18 @@
+resource "aws_instance" "this" {
+  ami                         = var.ami_id
+  instance_type               = var.instance_type
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = [var.security_group_id]
+  associate_public_ip_address = true
+
+  iam_instance_profile        = var.iam_instance_profile  # ✅ 추가
+
+  root_block_device {
+    volume_size = 8
+    volume_type = "gp3"
+  }
+
+  tags = {
+    Name = var.name
+  }
+}

--- a/infra/terraform/modules/ec2/outputs.tf
+++ b/infra/terraform/modules/ec2/outputs.tf
@@ -1,0 +1,7 @@
+output "instance_id" {
+  value = aws_instance.this.id
+}
+
+output "public_ip" {
+  value = aws_instance.this.public_ip
+}

--- a/infra/terraform/modules/ec2/variables.tf
+++ b/infra/terraform/modules/ec2/variables.tf
@@ -1,0 +1,29 @@
+variable "name" {
+  description = "EC2 인스턴스 이름"
+  type        = string
+}
+
+variable "ami_id" {
+  description = "EC2에 사용할 AMI ID"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 인스턴스 타입"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "서브넷 ID"
+  type        = string
+}
+
+variable "security_group_id" {
+  description = "보안 그룹 ID"
+  type        = string
+}
+
+variable "iam_instance_profile" {
+  description = "SSM용 IAM 인스턴스 프로필 이름"
+  type        = string
+}

--- a/infra/terraform/modules/iam/ssm_role/main.tf
+++ b/infra/terraform/modules/iam/ssm_role/main.tf
@@ -1,0 +1,28 @@
+resource "aws_iam_role" "this" {
+  name = var.name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = {
+    Name = var.name
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "this" {
+  name = "${var.name}-profile"
+  role = aws_iam_role.this.name
+}

--- a/infra/terraform/modules/iam/ssm_role/outputs.tf
+++ b/infra/terraform/modules/iam/ssm_role/outputs.tf
@@ -1,0 +1,7 @@
+output "role_name" {
+  value = aws_iam_role.this.name
+}
+
+output "instance_profile_name" {
+  value = aws_iam_instance_profile.this.name
+}

--- a/infra/terraform/modules/iam/ssm_role/variables.tf
+++ b/infra/terraform/modules/iam/ssm_role/variables.tf
@@ -1,0 +1,4 @@
+variable "name" {
+  description = "IAM Role 및 Instance Profile 이름"
+  type        = string
+}


### PR DESCRIPTION
## ✨ 작업 개요
- EC2 인스턴스를 .pem 없이 Systems Manager(SSM)로 접속할 수 있도록 SSM Role을 모듈화
- ssh_key_name 의존성을 제거하고, IAM Instance Profile 기반 접속 방식으로 전환

## 🔧 주요 변경 사항
- modules/iam/ssm_role 모듈 생성
  - IAM Role, Policy Attachment, Instance Profile 포함
- modules/ec2 수정
  - `key_name` 제거
  - `iam_instance_profile` 입력 변수 추가
- main.tf 수정
  - ssh_key_name 제거
  - SSM Role 모듈을 선언하여 EC2에 연결

## ✅ 개선 효과
- EC2에 .pem 없이 접속 가능 → 보안성 향상
- 키페어 없이도 GitHub Actions에서 EC2 배포 가능
- IAM Role 재사용 및 추적성 확보 (모듈화)

## 🧪 테스트
- `terraform plan` 정상 작동
- EC2 생성 후 SSM 접속 확인 (`Session Manager` 사용)

## 🧹 기타 참고
- `terraform.tfvars` 내 ssh_key_name 항목 제거 요망
- EC2에 직접 접속이 필요한 경우 SSM 권장 (SSH 22 포트는 선택적으로 닫을 수 있음)

---

### 체크리스트 ✅

- [x] EC2용 IAM Role 모듈화
- [x] ssh_key_name 제거
- [x] main.tf 및 ec2 모듈 수정
- [x] terraform apply 후 정상 동작 확인

## 📎 관련 이슈
- 없음 (or `#123`, 관련 티켓이 있다면)
