### PR TITLE
[feat] Terraform: IAM 정책 관리 체계 도입 및 역할/정책 구조화

### DIFF
--- a/infra/terraform/modules/iam/attach.tf
+++ b/infra/terraform/modules/iam/attach.tf
@@ -1,0 +1,14 @@
+resource "aws_iam_role_policy_attachment" "attach_state" {
+  role       = aws_iam_role.terraform_role.name
+  policy_arn = aws_iam_policy.terraform_state.arn
+}
+
+resource "aws_iam_role_policy_attachment" "attach_ec2" {
+  role       = aws_iam_role.terraform_role.name
+  policy_arn = aws_iam_policy.ec2_control.arn
+}
+
+resource "aws_iam_role_policy_attachment" "attach_iam_rds" {
+  role       = aws_iam_role.terraform_role.name
+  policy_arn = aws_iam_policy.iam_rds.arn
+}

--- a/infra/terraform/modules/iam/main.tf
+++ b/infra/terraform/modules/iam/main.tf
@@ -1,0 +1,22 @@
+resource "aws_iam_role" "terraform_role" {
+  name = "terraform-github-actions"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid = "AllowGithubActionsAssumeRole",
+        Effect = "Allow",
+        Principal = {
+          AWS = "arn:aws:iam::010438505844:user/terraform-github-actions"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Project = "kingkit"
+    Environment = "dev"
+  }
+}

--- a/infra/terraform/modules/iam/policies.tf
+++ b/infra/terraform/modules/iam/policies.tf
@@ -1,0 +1,20 @@
+resource "aws_iam_policy" "terraform_state" {
+  name        = "terraform-state-access"
+  path        = "/"
+  description = "Access to S3 and DynamoDB for Terraform backend"
+  policy      = file("${path.module}/../../../policies/terraform-state-access.json")
+}
+
+resource "aws_iam_policy" "ec2_control" {
+  name        = "ec2-control"
+  path        = "/"
+  description = "Control permissions for EC2 provisioning"
+  policy      = file("${path.module}/../../../policies/ec2-control.json")
+}
+
+resource "aws_iam_policy" "iam_rds" {
+  name        = "iam-ssm-rds"
+  path        = "/"
+  description = "IAM, SSM, and RDS management permissions"
+  policy      = file("${path.module}/../../../policies/iam-ssm-rds.json")
+}

--- a/infra/terraform/policies/ec2-control.json
+++ b/infra/terraform/policies/ec2-control.json
@@ -1,0 +1,29 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EC2Networking",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeVpcs", "ec2:DescribeSubnets", "ec2:DescribeRouteTables",
+        "ec2:DescribeNetworkInterfaces", "ec2:DescribeSecurityGroups",
+        "ec2:CreateSecurityGroup", "ec2:DeleteSecurityGroup",
+        "ec2:AuthorizeSecurityGroupIngress", "ec2:AuthorizeSecurityGroupEgress",
+        "ec2:RevokeSecurityGroupEgress"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EC2InstanceControl",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances", "ec2:TerminateInstances", "ec2:DescribeInstances",
+        "ec2:StartInstances", "ec2:StopInstances", "ec2:DescribeImages",
+        "ec2:DescribeInstanceTypes", "ec2:DescribeInstanceAttribute",
+        "ec2:DescribeVolumes", "ec2:DescribeInstanceCreditSpecifications",
+        "ec2:CreateTags", "ec2:DescribeTags"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/infra/terraform/policies/iam-ssm-rds.json
+++ b/infra/terraform/policies/iam-ssm-rds.json
@@ -1,0 +1,39 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "IAMSSMRoleManagement",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole", "iam:AttachRolePolicy", "iam:DeleteRole", "iam:GetRole",
+        "iam:TagRole", "iam:PassRole", "iam:ListRolePolicies", "iam:ListAttachedRolePolicies"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "IAMInstanceProfileManagement",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateInstanceProfile", "iam:DeleteInstanceProfile",
+        "iam:AddRoleToInstanceProfile", "iam:RemoveRoleFromInstanceProfile",
+        "iam:GetInstanceProfile", "iam:ListInstanceProfilesForRole"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "RDSControl",
+      "Effect": "Allow",
+      "Action": [
+        "rds:CreateDBInstance", "rds:DeleteDBInstance", "rds:DescribeDBInstances",
+        "rds:ModifyDBInstance", "rds:RebootDBInstance"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "STSCallerIdentity",
+      "Effect": "Allow",
+      "Action": ["sts:GetCallerIdentity"],
+      "Resource": "*"
+    }
+  ]
+}

--- a/infra/terraform/policies/terraform-state-access.json
+++ b/infra/terraform/policies/terraform-state-access.json
@@ -1,0 +1,23 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "TerraformS3StateAccess",
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::terraform-state-king"
+    },
+    {
+      "Sid": "TerraformS3ObjectAccess",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+      "Resource": "arn:aws:s3:::terraform-state-king/*"
+    },
+    {
+      "Sid": "TerraformDynamoDBLock",
+      "Effect": "Allow",
+      "Action": ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem", "dynamodb:UpdateItem"],
+      "Resource": "arn:aws:dynamodb:ap-northeast-2:010438505844:table/terraform-locks-king"
+    }
+  ]
+}


### PR DESCRIPTION
## 📌 작업 개요
IAM 권한 관리를 명확하게 구조화하기 위해 다음과 같은 작업을 수행했습니다:

- `policies/` 디렉토리 도입 → 정책 JSON 정적 파일 관리
- `aws_iam_policy` 리소스로 정책을 명시적으로 생성
- `aws_iam_role_policy_attachment`으로 역할과 정책을 분리 연결
- SSM Role 등 역할을 모듈로 구성하여 재사용성 강화

---

## 🔧 변경 사항 요약

- `terraform/policies/` 폴더 생성: 정적 정책 JSON 파일 3종
  - terraform-state-access.json
  - ec2-control.json
  - iam-ssm-rds.json

- `modules/iam/`
  - `main.tf`: terraform_role 생성
  - `policies.tf`: 정책 파일을 aws_iam_policy로 읽음
  - `attach.tf`: 정책을 role에 연결
  - `ssm_role/`: EC2 접속용 최소 권한 role은 별도로 유지

- `main.tf`에서 모듈 조합

---

## ✅ 기대 효과

| 항목 | 효과 |
|------|------|
| 정책 파일 관리 | Git으로 변경 추적 가능 |
| 권한 구성 분리 | 정책과 역할을 분리 관리, 확장 용이 |
| 보안성 | EC2 Role 최소 권한 원칙 적용 |
| 유지보수 | 역할-정책 명확히 분리되어 팀 단위 분업에 유리 |

---

## ✅ 체크리스트

- [x] 정책 JSON 파일 추가
- [x] aws_iam_policy 리소스 생성
- [x] 정책-역할 연결 완료
- [x] SSM Role은 별도 경량 모듈 유지
- [x] terraform plan 정상 작동 확인

---

## 🔗 관련 작업

- EC2에 .pem 없이 접속 가능한 SSM Role 체계와 연계됨
- 이후 GitHub Actions OIDC 기반 IAM 연결 시 이 구조 재활용 가능
