### PR TITLE
[feat] Terraform: IAM 인라인 정책 → 정책 파일(JSON) 외부화 구조로 전환

### DIFF
--- a/infra/terraform/modules/ec2/files/nginx.conf
+++ b/infra/terraform/modules/ec2/files/nginx.conf
@@ -1,0 +1,45 @@
+user nginx;
+worker_processes auto;
+
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    upstream backend {
+        server 127.0.0.1:8080 fail_timeout=0;  # Spring Boot 앱 포트
+    }
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            proxy_pass         http://backend;
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+
+        location /health {
+            return 200 'OK';
+            add_header Content-Type text/plain;
+        }
+    }
+}

--- a/infra/terraform/modules/ec2/main.tf
+++ b/infra/terraform/modules/ec2/main.tf
@@ -1,6 +1,9 @@
 resource "aws_instance" "this" {
   ami                         = var.ami_id
   instance_type               = var.instance_type
+
+  user_data = file("${path.module}/scripts/user_data.sh")
+
   subnet_id                   = var.subnet_id
   vpc_security_group_ids      = [var.security_group_id]
   associate_public_ip_address = true

--- a/infra/terraform/modules/ec2/scripts/user_data.sh
+++ b/infra/terraform/modules/ec2/scripts/user_data.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+echo "✅ [0] 시작: EC2 초기 설정 시작"
+
+# 1. 시스템 업데이트 및 유틸 설치
+yum update -y
+yum install -y git unzip curl
+
+# 2. setup-nginx.sh 실행 내용 직접 포함
+echo "🌐 [2] Nginx 설치"
+amazon-linux-extras enable nginx1
+yum install -y nginx
+systemctl enable nginx
+systemctl start nginx
+
+# 3. setup-docker-java.sh 실행 내용 직접 포함
+echo "🐳 [3] Docker + Java 설치"
+yum install -y docker
+systemctl enable docker
+systemctl start docker
+usermod -aG docker ec2-user
+
+yum install -y java-17-amazon-corretto
+java -version
+
+echo "✅ [4] EC2 초기화 완료"


### PR DESCRIPTION
## 📌 작업 개요
Terraform 인프라 구성 중 IAM 권한 정책을 인라인에서 JSON 정책 파일로 외부화하였습니다.

---

## 🧱 변경 사항

- `terraform-state-access.json` 정책 파일 추가
- `aws_iam_policy` 리소스로 해당 JSON 정책을 로드
- `aws_iam_role_policy_attachment`로 정책과 역할 연결
- 기존 인라인 정책 제거

---

## 🧠 기대 효과

| 항목 | 효과 |
|------|------|
| Git 관리 | 정책 변경 이력 추적 용이 (정책도 코드처럼 관리) |
| 가독성 | Terraform 코드에서 정책 내용 제거로 간결해짐 |
| 보안 | 정책 재사용/확장/최소 권한 구조로의 전환 가능 |
| 유지보수 | 정책 템플릿화 및 모듈화 용이

---

## 🧪 테스트 사항

- [x] `terraform plan` 성공
- [x] `terraform apply` 후 EC2, RDS, SSM 등 정상 작동 확인

---

## 🔮 다음 단계 제안

- 정책 분리: `rds-control.json`, `ec2-control.json`, `iam-ssm-role.json` 등 분할 가능
- GitHub Actions OIDC 연동용 정책 추가

---

## 🔗 관련 없음
