### PR TITLE
[fix] Terraform: EC2 user_data 수정 실패 대응 - ModifyInstanceAttribute 권한 추가

### DIFF
--- a/infra/terraform/policies/ec2-control.json
+++ b/infra/terraform/policies/ec2-control.json
@@ -21,7 +21,8 @@
         "ec2:StartInstances", "ec2:StopInstances", "ec2:DescribeImages",
         "ec2:DescribeInstanceTypes", "ec2:DescribeInstanceAttribute",
         "ec2:DescribeVolumes", "ec2:DescribeInstanceCreditSpecifications",
-        "ec2:CreateTags", "ec2:DescribeTags"
+        "ec2:CreateTags", "ec2:DescribeTags",
+        "ec2:ModifyInstanceAttribute" 
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
## 🔧 수정 개요
Terraform apply 중 EC2 user_data 변경 시 `ec2:ModifyInstanceAttribute` 권한 부족으로 인해 실패 발생.

---

## 🧾 에러 메시지 요약

```text
│ Error: error modifying EC2 Instance Attribute: UnauthorizedOperation:
│ You are not authorized to perform this operation.
│ Status Code: 403, Request ID: ...
