### PR TITLE
[fix] ec2-control 정책 업데이트 오류 대응 - IAM 정책에 CreatePolicyVersion 권한 추가

### DIFF
--- a/infra/terraform/policies/iam-ssm-rds.json
+++ b/infra/terraform/policies/iam-ssm-rds.json
@@ -21,6 +21,16 @@
       "Resource": "*"
     },
     {
+      "Sid": "IAMPolicyVersionControl",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreatePolicyVersion",
+        "iam:SetDefaultPolicyVersion",
+        "iam:DeletePolicyVersion"
+      ],
+      "Resource": "arn:aws:iam::010438505844:policy/ec2-control"
+    },
+    {
       "Sid": "RDSControl",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
✅ 변경 사항
iam-ssm-rds.json 정책 파일에 아래 권한 추가:

{
  "Sid": "IAMPolicyVersionControl",
  "Effect": "Allow",
  "Action": [
    "iam:CreatePolicyVersion",
    "iam:SetDefaultPolicyVersion",
    "iam:DeletePolicyVersion"
  ],
  "Resource": "arn:aws:iam::010438505844:policy/ec2-control"
}
🧠 사유
항목	내용
발생 원인	Terraform이 정책 내용을 업데이트하려 할 때 PolicyVersion 생성 권한 없음
적용 위치	기존 IAM 권한을 보유한 iam-ssm-rds.json에 명시
보안 고려	리소스 ARN을 명시하여 최소 권한 원칙 유지

📌 확인 사항
 terraform apply -target=module.iam 테스트 완료
