### PR TITLE
[Chore] RDS 엔진 버전 기본값을 17.4로 업데이트

### DIFF
--- a/infra/terraform/modules/rds/variables.tf
+++ b/infra/terraform/modules/rds/variables.tf
@@ -4,7 +4,7 @@ variable "identifier" {
 
 variable "engine_version" {
   type    = string
-  default = "17.2"
+  default = "17.4"
 }
 
 variable "instance_class" {


### PR DESCRIPTION
RDS 엔진 버전의 기본값을 기존 \`17.2\`에서 \`17.4\`로 업데이트하였습니다. 최신 버전 반영을 위한 개선입니다.