### PR TITLE
Improve billing-service unit coverage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,9 +50,11 @@ subprojects {
     if (project.file("src/main").exists()) {
         if (!isLibrary) {
             apply(plugin = "org.springframework.boot")
-            extensions.configure<JavaPluginExtension> {
-                toolchain.languageVersion.set(JavaLanguageVersion.of(17))
-            }
+        }
+        extensions.configure<JavaPluginExtension> {
+            toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+        }
+        if (!isLibrary) {
             dependencies {
                 add("implementation", "org.springframework.boot:spring-boot-starter")
             }

--- a/core/billing-service/src/test/java/com/kingkit/billing_service/config/webhook/WebhookSignatureFilterTest.java
+++ b/core/billing-service/src/test/java/com/kingkit/billing_service/config/webhook/WebhookSignatureFilterTest.java
@@ -1,0 +1,76 @@
+package com.kingkit.billing_service.config.webhook;
+
+import com.kingkit.billing_service.support.fixture.composite.WebhookTestFixture;
+import com.kingkit.billing_service.util.TossSignatureVerifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import jakarta.servlet.FilterChain;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebhookSignatureFilterTest {
+
+    private WebhookSignatureFilter filter;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        TossSignatureVerifier verifier = new TossSignatureVerifier();
+        Field f = TossSignatureVerifier.class.getDeclaredField("secretKey");
+        f.setAccessible(true);
+        f.set(verifier, WebhookTestFixture.TOSS_SECRET_KEY);
+        filter = new WebhookSignatureFilter(verifier);
+    }
+
+    @Test
+    @DisplayName("shouldNotFilter returns false for webhook path")
+    void shouldFilterWebhookPath() {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/webhook/toss");
+        assertThat(filter.shouldNotFilter(req)).isFalse();
+    }
+
+    @Test
+    @DisplayName("shouldNotFilter returns true for other paths")
+    void shouldNotFilterOtherPath() {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/health");
+        assertThat(filter.shouldNotFilter(req)).isTrue();
+    }
+
+    @Test
+    @DisplayName("invalid signature results in 401")
+    void invalidSignature_responds401() throws Exception {
+        String body = "{\"ok\":true}";
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/webhook/toss");
+        req.setContent(body.getBytes(StandardCharsets.UTF_8));
+        req.addHeader("Toss-Signature", "wrong");
+
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = (request, response) -> request.getInputStream().readAllBytes();
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(res.getStatus()).isEqualTo(401);
+        assertThat(res.getContentAsString()).contains("Invalid Toss Signature");
+    }
+
+    @Test
+    @DisplayName("valid signature allows request")
+    void validSignature_passes() throws Exception {
+        String body = "{\"ok\":true}";
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/webhook/toss");
+        req.setContent(body.getBytes(StandardCharsets.UTF_8));
+        req.addHeader("Toss-Signature", WebhookTestFixture.validSignature(body));
+
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = (request, response) -> request.getInputStream().readAllBytes();
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(res.getStatus()).isNotEqualTo(401);
+    }
+}

--- a/core/billing-service/src/test/java/com/kingkit/billing_service/domain/payment/PaymentMethodTest.java
+++ b/core/billing-service/src/test/java/com/kingkit/billing_service/domain/payment/PaymentMethodTest.java
@@ -52,4 +52,17 @@ class PaymentMethodTest {
         // then
         assertThat(method.isActivated()).isFalse();
     }
+
+    @Test
+    @DisplayName("create() 정적 팩토리는 필드를 채우고 활성화된 PaymentMethod를 반환한다")
+    void create_staticFactory_returnsActiveMethod() {
+        PaymentMethod method = PaymentMethod.create(10L, "key-123", "Visa", "****-****-****-1111");
+
+        assertThat(method.getUserId()).isEqualTo(10L);
+        assertThat(method.getBillingKey()).isEqualTo("key-123");
+        assertThat(method.getCardCompany()).isEqualTo("Visa");
+        assertThat(method.getCardNumberMasked()).isEqualTo("****-****-****-1111");
+        assertThat(method.isActive()).isTrue();
+        assertThat(method.getRegisteredAt()).isNotNull();
+    }
 }

--- a/core/billing-service/src/test/java/com/kingkit/billing_service/domain/payment/PaymentStatusTest.java
+++ b/core/billing-service/src/test/java/com/kingkit/billing_service/domain/payment/PaymentStatusTest.java
@@ -1,0 +1,36 @@
+package com.kingkit.billing_service.domain.payment;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PaymentStatusTest {
+
+    @Test
+    @DisplayName("from() 메서드는 대소문자와 무관하게 상태를 매핑한다")
+    void from_mapsValueIgnoringCase() {
+        assertThat(PaymentStatus.from("success")).isEqualTo(PaymentStatus.SUCCESS);
+        assertThat(PaymentStatus.from("FAILED")).isEqualTo(PaymentStatus.FAILED);
+        assertThat(PaymentStatus.from("Canceled")).isEqualTo(PaymentStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("from() 메서드는 알 수 없는 값을 입력하면 UNKNOWN을 반환한다")
+    void from_unknownValue_returnsUnknown() {
+        assertThat(PaymentStatus.from("something")).isEqualTo(PaymentStatus.UNKNOWN);
+    }
+
+    @Test
+    @DisplayName("상태 편의 메서드들은 올바른 값을 반환한다")
+    void helperMethods_workCorrectly() {
+        assertThat(PaymentStatus.SUCCESS.isSuccess()).isTrue();
+        assertThat(PaymentStatus.SUCCESS.isFailure()).isFalse();
+        assertThat(PaymentStatus.SUCCESS.isPending()).isFalse();
+
+        assertThat(PaymentStatus.FAILED.isFailure()).isTrue();
+        assertThat(PaymentStatus.CANCELED.isFailure()).isTrue();
+
+        assertThat(PaymentStatus.IN_PROGRESS.isPending()).isTrue();
+    }
+}

--- a/core/billing-service/src/test/java/com/kingkit/billing_service/domain/subscription/SubscriptionTest.java
+++ b/core/billing-service/src/test/java/com/kingkit/billing_service/domain/subscription/SubscriptionTest.java
@@ -1,0 +1,94 @@
+package com.kingkit.billing_service.domain.subscription;
+
+import com.kingkit.billing_service.domain.payment.PaymentMethod;
+import com.kingkit.billing_service.support.fixture.domain.PaymentMethodFixture;
+import com.kingkit.billing_service.support.fixture.domain.SubscriptionPlanFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SubscriptionTest {
+
+    private Subscription createActiveSubscription(LocalDateTime nextBillingAt, int durationDays) {
+        PaymentMethod method = PaymentMethodFixture.active(100L);
+        SubscriptionPlan plan = SubscriptionPlanFixture.withDuration(durationDays);
+        return Subscription.builder()
+                .userId(100L)
+                .plan(plan)
+                .paymentMethod(method)
+                .status(SubscriptionStatus.ACTIVE)
+                .startedAt(LocalDateTime.now().minusDays(1))
+                .nextBillingAt(nextBillingAt)
+                .build();
+    }
+
+    @Test
+    @DisplayName("markCanceled() sets status to CANCELED")
+    void markCanceled_setsStatus() {
+        Subscription sub = createActiveSubscription(LocalDateTime.now(), 30);
+        sub.markCanceled();
+        assertThat(sub.getStatus()).isEqualTo(SubscriptionStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("markExpired() sets status to EXPIRED")
+    void markExpired_setsStatus() {
+        Subscription sub = createActiveSubscription(LocalDateTime.now(), 30);
+        sub.markExpired();
+        assertThat(sub.getStatus()).isEqualTo(SubscriptionStatus.EXPIRED);
+    }
+
+    @Test
+    @DisplayName("renewNextBilling() adds plan duration")
+    void renewNextBilling_addsDuration() {
+        LocalDateTime next = LocalDateTime.now();
+        Subscription sub = createActiveSubscription(next, 7);
+
+        sub.renewNextBilling();
+
+        assertThat(sub.getNextBillingAt()).isAfter(next.plusDays(6));
+        assertThat(sub.getNextBillingAt()).isBefore(next.plusDays(8));
+    }
+
+    @Test
+    @DisplayName("markBillingSuccess updates startedAt when null and renews next billing")
+    void markBillingSuccess_updatesFields() {
+        LocalDateTime next = LocalDateTime.now();
+        PaymentMethod method = PaymentMethodFixture.active(100L);
+        SubscriptionPlan plan = SubscriptionPlanFixture.withDuration(30);
+        Subscription sub = Subscription.builder()
+                .userId(100L)
+                .plan(plan)
+                .paymentMethod(method)
+                .status(SubscriptionStatus.ACTIVE)
+                .startedAt(null)
+                .nextBillingAt(next)
+                .build();
+
+        LocalDateTime paidAt = LocalDateTime.now();
+        sub.markBillingSuccess(paidAt);
+
+        assertThat(sub.getStartedAt()).isEqualTo(paidAt);
+        assertThat(sub.getNextBillingAt()).isAfter(next);
+    }
+
+    @Test
+    @DisplayName("markBillingSuccess throws when subscription is not active")
+    void markBillingSuccess_inactive_throws() {
+        Subscription sub = Subscription.builder()
+                .userId(1L)
+                .plan(SubscriptionPlanFixture.basicPlan())
+                .paymentMethod(PaymentMethodFixture.active(1L))
+                .status(SubscriptionStatus.CANCELED)
+                .startedAt(LocalDateTime.now())
+                .nextBillingAt(LocalDateTime.now())
+                .build();
+
+        assertThatThrownBy(() -> sub.markBillingSuccess(LocalDateTime.now()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/core/billing-service/src/test/java/com/kingkit/billing_service/util/DateRangeTest.java
+++ b/core/billing-service/src/test/java/com/kingkit/billing_service/util/DateRangeTest.java
@@ -1,0 +1,23 @@
+package com.kingkit.billing_service.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DateRangeTest {
+
+    @Test
+    void startOf_returnsStartOfDay() {
+        LocalDate date = LocalDate.of(2025, 6, 1);
+        assertThat(DateRange.startOf(date)).isEqualTo(date.atStartOfDay());
+    }
+
+    @Test
+    void endOf_returnsEndOfDay() {
+        LocalDate date = LocalDate.of(2025, 6, 1);
+        assertThat(DateRange.endOf(date)).isEqualTo(date.atTime(LocalTime.MAX));
+    }
+}

--- a/core/billing-service/src/test/java/com/kingkit/billing_service/util/OrderIdGeneratorTest.java
+++ b/core/billing-service/src/test/java/com/kingkit/billing_service/util/OrderIdGeneratorTest.java
@@ -1,0 +1,16 @@
+package com.kingkit.billing_service.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrderIdGeneratorTest {
+
+    @Test
+    void generate_returnsFormattedOrderId() {
+        OrderIdGenerator generator = new OrderIdGenerator();
+        String id = generator.generate();
+
+        assertThat(id).matches("order-\\d{14}-[0-9a-f]{8}");
+    }
+}

--- a/core/billing-service/src/test/java/com/kingkit/billing_service/util/TossSignatureVerifierTest.java
+++ b/core/billing-service/src/test/java/com/kingkit/billing_service/util/TossSignatureVerifierTest.java
@@ -1,0 +1,50 @@
+package com.kingkit.billing_service.util;
+
+import com.kingkit.billing_service.support.fixture.composite.WebhookTestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TossSignatureVerifierTest {
+
+    private TossSignatureVerifier verifier;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        verifier = new TossSignatureVerifier();
+        Field f = TossSignatureVerifier.class.getDeclaredField("secretKey");
+        f.setAccessible(true);
+        f.set(verifier, WebhookTestFixture.TOSS_SECRET_KEY);
+    }
+
+    @Test
+    @DisplayName("verify() returns true for valid signature")
+    void verify_validSignature_returnsTrue() {
+        String body = "{\"hello\":\"world\"}";
+        String sig = WebhookTestFixture.validSignature(body);
+
+        assertThat(verifier.verify(body, sig)).isTrue();
+    }
+
+    @Test
+    @DisplayName("verify() returns false for invalid signature")
+    void verify_invalidSignature_returnsFalse() {
+        String body = "{\"hello\":\"world\"}";
+
+        assertThat(verifier.verify(body, "wrong")).isFalse();
+    }
+
+    @Test
+    @DisplayName("verify() returns false when secretKey is null")
+    void verify_nullSecretKey_returnsFalse() throws Exception {
+        Field f = TossSignatureVerifier.class.getDeclaredField("secretKey");
+        f.setAccessible(true);
+        f.set(verifier, null);
+
+        assertThat(verifier.verify("body", "sig")).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for `Subscription` entity logic
- cover utility classes `DateRange`, `OrderIdGenerator`, and `TossSignatureVerifier`
- verify `WebhookSignatureFilter` behaviour for valid/invalid signatures
- exercise `PaymentStatus` conversion helpers
- add factory method test for `PaymentMethod`

## Testing
- `./gradlew :core:billing-service:test --tests "*PaymentStatusTest"`
- `./gradlew :core:billing-service:test --tests "*DateRangeTest"`
- `./gradlew :core:billing-service:test --tests "*OrderIdGeneratorTest"`
- `./gradlew :core:billing-service:test --tests "*TossSignatureVerifierTest"`
- `./gradlew :core:billing-service:test --tests "*WebhookSignatureFilterTest"`
- `./gradlew :core:billing-service:test --tests "*SubscriptionTest"`
- `./gradlew :core:billing-service:test --tests "*PaymentMethodTest"`


------
https://chatgpt.com/codex/tasks/task_e_68590a78f7a083308062d5d1f0b9d844