### PR TITLE
feat: allow ssm:SendCommand and describe permissions for SSM remote e…

### DIFF
--- a/infra/terraform/modules/iam/attach.tf
+++ b/infra/terraform/modules/iam/attach.tf
@@ -17,3 +17,8 @@ resource "aws_iam_user_policy_attachment" "user_attach_ecr_push" {
   user       = "terraform-github-actions"
   policy_arn = aws_iam_policy.ecr_push.arn
 }
+
+resource "aws_iam_user_policy_attachment" "user_attach_ssm_exec_policy" {
+  user       = "terraform-github-actions"
+  policy_arn = aws_iam_policy.ssm_exec_policy.arn
+}

--- a/infra/terraform/modules/iam/policies.tf
+++ b/infra/terraform/modules/iam/policies.tf
@@ -25,3 +25,10 @@ resource "aws_iam_policy" "ecr_push" {
   description = "ECR push permissions"
   policy      = file("${path.module}/../../policies/ecr-push.json")
 }
+
+resource "aws_iam_policy" "ssm_exec_policy" {
+  name   = "ssm-send-command-policy"
+  path        = "/"
+  description = "SSM send permissions"
+  policy = file("${path.module}/../../policies/ssm-exec-policy.json")
+}

--- a/infra/terraform/policies/ssm-exec-policy.json
+++ b/infra/terraform/policies/ssm-exec-policy.json
@@ -1,0 +1,27 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowSSMSendCommand",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand"
+      ],
+      "Resource": [
+        "arn:aws:ec2:ap-northeast-2:010438505844:instance/*",
+        "arn:aws:ssm:ap-northeast-2::document/AWS-RunShellScript"
+      ]
+    },
+    {
+      "Sid": "AllowSSMDescribe",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:ListCommands",
+        "ssm:ListCommandInvocations",
+        "ssm:GetCommandInvocation",
+        "ssm:ListDocuments"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
Add necessary permissions for terraform-github-actions user to execute remote shell commands on EC2 via AWS SSM RunCommand